### PR TITLE
fix(abi-import): importing abi from artifacts throws warnings, fixed

### DIFF
--- a/src/entities/engine.ts
+++ b/src/entities/engine.ts
@@ -2,17 +2,15 @@ import { utils, constants } from 'ethers'
 import { Token } from '@uniswap/sdk-core'
 import { parseWei, Wei } from 'web3-units'
 import { Interface } from '@ethersproject/abi'
-import {
-  bytecode,
-  abi
-} from '@primitivefinance/rmm-core/artifacts/contracts/PrimitiveEngine.sol/PrimitiveEngine.json'
+import EngineArtifact from '@primitivefinance/rmm-core/artifacts/contracts/PrimitiveEngine.sol/PrimitiveEngine.json'
 
 /**
  * @notice Represents the PrimitiveEngine.sol smart contract
  */
 export class Engine extends Token {
-  public static BYTECODE: string = bytecode
-  public static INTERFACE: Interface = new Interface(abi)
+  public static BYTECODE: string = EngineArtifact.bytecode
+  public static INTERFACE: Interface = new Interface(EngineArtifact.abi)
+  public static ABI: any = EngineArtifact.abi
 
   /**
    * @notice Used to calculate minimum liquidity based on lowest decimals of risky/stable
@@ -60,7 +58,7 @@ export class Engine extends Token {
   constructor(factory: string, risky: Token, stable: Token) {
     super(
       risky.chainId,
-      Engine.computeEngineAddress(factory, risky.address, stable.address, bytecode),
+      Engine.computeEngineAddress(factory, risky.address, stable.address, EngineArtifact.bytecode),
       18,
       'RMM-01',
       'Primitive RMM-01 LP Token'

--- a/src/factoryManager.ts
+++ b/src/factoryManager.ts
@@ -1,10 +1,12 @@
 import invariant from 'tiny-invariant'
 import { Interface } from '@ethersproject/abi'
 import { AddressZero } from '@ethersproject/constants'
-import { abi } from '@primitivefinance/rmm-core/artifacts/contracts/PrimitiveFactory.sol/PrimitiveFactory.json'
+import FactoryArtifact from '@primitivefinance/rmm-core/artifacts/contracts/PrimitiveFactory.sol/PrimitiveFactory.json'
 
 export abstract class FactoryManager {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(FactoryArtifact.abi)
+  public static BYTECODE: string = FactoryArtifact.bytecode
+  public static ABI: any = FactoryArtifact.abi
 
   private constructor() {}
 

--- a/src/peripheryManager.ts
+++ b/src/peripheryManager.ts
@@ -4,7 +4,7 @@ import { Interface } from '@ethersproject/abi'
 import { parseWei, Percentage, toBN, Wei } from 'web3-units'
 import { NativeCurrency } from '@uniswap/sdk-core'
 import { AddressZero } from '@ethersproject/constants'
-import { abi } from '@primitivefinance/rmm-manager/artifacts/contracts/PrimitiveManager.sol/PrimitiveManager.json'
+import ManagerArtifact from '@primitivefinance/rmm-manager/artifacts/contracts/PrimitiveManager.sol/PrimitiveManager.json'
 
 import { Pool, PoolSides } from './entities/pool'
 import { Engine } from './entities/engine'
@@ -53,7 +53,9 @@ export interface RemoveOptions extends LiquidityOptions, RecipientOptions, Nativ
 }
 
 export abstract class PeripheryManager extends SelfPermit {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(ManagerArtifact.abi)
+  public static BYTECODE: string = ManagerArtifact.bytecode
+  public static ABI: any = ManagerArtifact.abi
 
   private constructor() {
     super()

--- a/src/selfPermit.ts
+++ b/src/selfPermit.ts
@@ -1,7 +1,7 @@
-import { Token } from '@uniswap/sdk-core'
-import { Interface } from '@ethersproject/abi'
-import { abi } from '@primitivefinance/rmm-core/artifacts/contracts/PrimitiveFactory.sol/PrimitiveFactory.json' // todo: fix placeholder
 import { BigNumber } from 'ethers'
+import { Interface } from '@ethersproject/abi'
+import { Token } from '@uniswap/sdk-core'
+import ManagerArtifact from '@primitivefinance/rmm-manager/artifacts/contracts/PrimitiveManager.sol/PrimitiveManager.json'
 
 export interface StandardPermitArguments {
   v: 0 | 1 | 27 | 28
@@ -26,7 +26,7 @@ function isAllowedPermit(permitOptions: PermitOptions): permitOptions is Allowed
 }
 
 export abstract class SelfPermit {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(ManagerArtifact.abi)
 
   protected constructor() {}
 

--- a/src/swapManager.ts
+++ b/src/swapManager.ts
@@ -3,7 +3,7 @@ import invariant from 'tiny-invariant'
 import { Interface } from '@ethersproject/abi'
 import { AddressZero } from '@ethersproject/constants'
 import { parseWei, Percentage, toBN, Wei } from 'web3-units'
-import { abi } from '@primitivefinance/rmm-manager/artifacts/contracts/PrimitiveManager.sol/PrimitiveManager.json'
+import ManagerArtifact from '@primitivefinance/rmm-manager/artifacts/contracts/PrimitiveManager.sol/PrimitiveManager.json'
 
 import { Pool } from './entities/pool'
 import { PeripheryManager, NativeOptions } from './peripheryManager'
@@ -27,7 +27,9 @@ export interface SwapOptions extends DefaultOptions, NativeOptions {
 }
 
 export abstract class SwapManager extends SelfPermit {
-  public static INTERFACE: Interface = new Interface(abi)
+  public static INTERFACE: Interface = new Interface(ManagerArtifact.abi)
+  public static BYTECODE: string = ManagerArtifact.bytecode
+  public static ABI: any = ManagerArtifact.abi
 
   private constructor() {
     super()


### PR DESCRIPTION
Updates abi imports as a constant rather than destructured. Also adds abi static getter to interfaces with the contracts. Updates selfPermit to use the manager rather than the factory, which was a placeholder