### PR TITLE
bump(rmm-math): fixes reported price math

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@primitivefi/rmm-core": "^2.0.0-beta.5",
     "@primitivefi/rmm-manager": "^2.0.0-beta.5",
-    "@primitivefi/rmm-math": "^2.0.0-beta.2",
+    "@primitivefi/rmm-math": "^2.0.0-beta.3",
     "@uniswap/sdk-core": "^3.0.1",
     "tiny-invariant": "^1.1.0",
     "tiny-warning": "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1591,10 +1591,10 @@
     "@primitivefi/rmm-core" "2.0.0-beta.5"
     base64-sol "^1.1.0"
 
-"@primitivefi/rmm-math@^2.0.0-beta.2":
-  version "2.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@primitivefi/rmm-math/-/rmm-math-2.0.0-beta.2.tgz#97fed84c645c0cd0e8a00c47936ba413d532057a"
-  integrity sha512-88bEYPHCHD3f2y1KvyoVr67ydTZli7NnORT+SAhKsXD8n2UnmfrowNNvHWfDpnx84B0UXscEJZGGYiyxa7UYQg==
+"@primitivefi/rmm-math@^2.0.0-beta.3":
+  version "2.0.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@primitivefi/rmm-math/-/rmm-math-2.0.0-beta.3.tgz#07427901672105ee5b462fe9746b55590747fc38"
+  integrity sha512-zyZHNQHwM1GOzmNWWPwvndq/xOSqQKRMXmmaVljxJPJqpdzliLB2O074dYttwMX1972csn0ZfsWQk+hiDo67Cw==
   dependencies:
     gaussian "^1.2.0"
     numeric "^1.2.6"


### PR DESCRIPTION
# Changelog
- Updates rmm-math package to v2.0.0-beta.3

We discovered that the reported price formula in the whitepaper was incorrect. This updated math package fixes the error to the correct math formula.